### PR TITLE
Add validation for correct pixels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 led_shim-*.tar
 
+.elixir_ls

--- a/lib/led_shim.ex
+++ b/lib/led_shim.ex
@@ -95,8 +95,12 @@ defmodule LEDShim do
     {:noreply, s}
   end
 
-  def handle_call({:set_pixel, pixel, color, brightness}, _from, s) do
+  def handle_call({:set_pixel, pixel, color, brightness}, _from, s) when pixel in 0..27 do
     {:reply, :ok, do_set_pixel(pixel, color, brightness, s)}
+  end
+
+  def handle_call({:set_pixel, _pixel, _color, _brightness}, _from, s) do
+    {:reply, {:error, "Pixel out of LED Shim range of 0..27"}, s}
   end
 
   def handle_call({:set_all, color, brightness}, _from, s) do

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule LEDShim.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:is31fl3731, github: "mobileoverlord/is31fl3731"}
+      {:is31fl3731, github: "mobileoverlord/is31fl3731"},
+      {:propcheck, "~> 1.0", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,6 @@
   "circuits_i2c": {:hex, :circuits_i2c, "0.2.0", "e235556a9f09b757df5e778f46e23fe49fe17e71ee6bc206d90524e993fee834", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
   "is31fl3731": {:git, "https://github.com/mobileoverlord/is31fl3731.git", "0b083a8006155c5ecd02092d96c7bfe59205ed24", []},
+  "propcheck": {:hex, :propcheck, "1.1.2", "6ec0e74cfd535ee3923c359f1f1f572451d9915faf9b8312245993e42edd7c84", [:mix], [{:proper, "~> 1.2", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
+  "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm"},
 }

--- a/test/led_shim_test.exs
+++ b/test/led_shim_test.exs
@@ -1,14 +1,27 @@
 defmodule LEDShimTest do
   use ExUnit.Case
+  use PropCheck
   doctest LEDShim
 
-  test "errors when LED pixel is out of bounds" do
+  property "errors when LED pixel is out of bounds" do
     LEDShim.start_link
-    assert {:error, _message} = LEDShim.set_pixel(28, {255, 255, 255}, 0.2)
+    forall {pixel, red, green, blue, brightness} <- {range(28, 1_000_000_000), color(), color(), color(), brightness()} do
+      {:error, "Pixel out of LED Shim range of 0..27"} == LEDShim.set_pixel(pixel, {red, green, blue}, brightness)
+    end
   end
 
-  test "accepts pixels between 0 and 27" do
+  property "accepts pixels between 0 and 27" do
     LEDShim.start_link
-    for i <- 0..27, do: assert :ok = LEDShim.set_pixel(i, {255, 255, 255}, 0.2)
+    forall {pixel, red, green, blue, brightness} <- {range(0, 27), color(), color(), color(), brightness()} do
+      :ok == LEDShim.set_pixel(pixel, {red, green, blue}, brightness)
+    end
+  end
+
+  defp color() do
+    range(0, 255)
+  end
+
+  defp brightness() do
+    oneof([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0])
   end
 end

--- a/test/led_shim_test.exs
+++ b/test/led_shim_test.exs
@@ -2,7 +2,13 @@ defmodule LEDShimTest do
   use ExUnit.Case
   doctest LEDShim
 
-  test "greets the world" do
-    assert LEDShim.hello() == :world
+  test "errors when LED pixel is out of bounds" do
+    LEDShim.start_link
+    assert {:error, _message} = LEDShim.set_pixel(28, {255, 255, 255}, 0.2)
+  end
+
+  test "accepts pixels between 0 and 27" do
+    LEDShim.start_link
+    for i <- 0..27, do: assert :ok = LEDShim.set_pixel(i, {255, 255, 255}, 0.2)
   end
 end


### PR DESCRIPTION
This PR adds:

1) A guard clause that ensures a correct pixel number is used
2) The Elixir LSP to `.gitignore`
3) The `ProperER` hex package and 2 property tests to ensure all valid pixels are valid

Further Improvements:

I'm far from experienced in using PropER, and I couldn't figure out how to use `:infinity` inside a property test. I have a hard coded error message which I'm less than pleased with, but PropER seems to enforce literal matches, though this is likely just me not knowing how to implement this better. There are also no tests for valid/invalid RGB or Brightness values. I also have little experience in testing `GenServer` implementations so I'm unsure of the best practices in testing public vs private GenServer APIs